### PR TITLE
fix blog and project section layout  bug

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,7 +30,7 @@ layout: default
   id="blog"
   class="container mx-auto flex flex-col items-center justify-center min-h-screen"
 >
-  <div class="py-16">
+  <div class="py-16 w-full">
     <h2 class="text-3xl font-bold text-center md:text-left">
       {{ site.data[site.active_lang].strings.home.blog_title | default:
       site.data['en'].strings.home.blog_title}}
@@ -61,7 +61,7 @@ layout: default
   id="projects"
   class="container mx-auto flex flex-col items-center justify-center min-h-screen"
 >
-  <div class="py-16">
+  <div class="py-16 w-full">
     <h2 class="text-3xl font-bold text-center md:text-left">
       {{ site.data[site.active_lang].strings.home.projects_title | default:
       site.data['en'].strings.home.projects_title}}


### PR DESCRIPTION
## Bug
In the home layout, the blog and project section goes out of alignment when the title is short. we can see that in the image below
![Mask group](https://github.com/user-attachments/assets/7839a077-e22c-4dda-8f61-86c07fe150de)

This is because the blog content width or project content width is not up to the max width.

## Solution 
Make the parent width 100%. this will make the container flex item always 100%.