### PR TITLE
Fix grammar and typo in english localization string for contact_me

### DIFF
--- a/_data/en/strings.yml
+++ b/_data/en/strings.yml
@@ -1,5 +1,5 @@
 home:
-  contact_me: "You can contact me for any of this channels:"
+  contact_me: "You can contact me on any of these channels:"
   blog_title: "Blog: Last Posts"
   see_more_posts: "See More Posts ->"
   projects_title: "Last Projects"


### PR DESCRIPTION
As titled. There is a grammar fix and a typo fix.