### PR TITLE
Generate a different image for each post card

### DIFF
--- a/_includes/post_card.html
+++ b/_includes/post_card.html
@@ -1,8 +1,11 @@
 <div class="flex flex-col justify-between">
   <div class="flex flex-col justify-between max-w-lg">
     <a href="{{include.post.url | relative_url}}" aria-label="Post Url">
+        {% assign random_number = include.post_index | default: 0 %}
+        {% assign random_image = 'https://picsum.photos/600/400/?blur&random=' | append: random_number %}
+        {% assign post_image = include.post.image | default: random_image %}
       <div class="hover:opacity-90 transition duration-300 w-full h-60 bg-cover bg-center"
-        style="background-image: url('{{ post.image | default: 'https://picsum.photos/600/400/?blur' }}')">
+        style="background-image: url('{{ post_image }}')">
       </div>
     </a>
     <div class="pt-6">

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -32,8 +32,11 @@ layout: default
   <div
     class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-12 gap-y-16 py-8 md:py-16"
   >
-    {% for post in rest_posts %} {% include post_card.html post=post %} {%
-    endfor %}
+    {% assign post_index = 0 %}
+    {% for post in rest_posts %}
+      {% include post_card.html post=post post_index=post_index %}
+      {% assign post_index = post_index | plus: 1 %}
+    {% endfor %}
   </div>
   {% endif%}
 </section>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -38,7 +38,9 @@ layout: default
     <div
       class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-12 gap-y-16 py-8 md:py-16"
     >
-      {% for post in site.posts limit:3 %} {% include post_card.html post=post%}
+      {% for post in site.posts limit:3 %}
+        {% include post_card.html post=post post_index=post_index %}
+        {% assign post_index = post_index | plus: 1 %}
       {% endfor %}
     </div>
 


### PR DESCRIPTION
Currently, the random blur image generated for post cards without a post.image are cached by the browser for all posts. So, the same image repeats multiple times. Here is a screenshot:
<img width="1438" alt="Screenshot 2025-06-21 at 10 31 16 AM" src="https://github.com/user-attachments/assets/d950bd6b-9498-47ac-864b-5b3fcd1e263a" />

The site https://picsum.photos/ provides a way to generate different images for each link to the image generator. The website says:

> To request multiple images of the same size in your browser, add the random query param to prevent the images from being cached:
> ```
> <img src="https://picsum.photos/200/300?random=1">
> <img src="https://picsum.photos/200/300?random=2">
> ```

This PR takes advantage of this by generating an index for each post that is generated in the loop in both `blog.html` and `home.html`. This index value is passed to `post_card.html` as a variable `post_index`. If this `post_index` is set, then it passes it in as the value of the param `random` to `https://picsum.photos/`; else `random` is set to `0`.

That way multiple posts will have different images as seen in the screenshot below.
<img width="1516" alt="Screenshot 2025-06-21 at 10 37 04 AM" src="https://github.com/user-attachments/assets/8ef8d9c6-dfc6-4d1b-af0b-1c871e29ccd0" />


