### PR TITLE
remove text-black css and some small change in README and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 A clean, versatile Jekyll theme with minimalist design and robust features.
 Ideal for portfolios, blogs, and project showcases with responsive layouts and easy customization.
 
-## ScreenShots
+## Screenshots
 
 ### Home Layout
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -52,7 +52,7 @@
         {% endif %}
         <div class="text-sm text-blueGray-500 font-semibold py-1">
           © <span id="get-current-year">{{currentYear}}</span>
-          <a href="https://www.creative-tim.com/product/notus-js" class="text-blueGray-500 hover:text-gray-800"
+          <a href="/" class="text-blueGray-500 hover:text-gray-800"
             target="_blank" aria-label="Creative C">{{site.title}}.</a>
           All rights reserved.
           <p class="text-xs pt-4">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,7 +5,7 @@ layout: default
 <link rel="stylesheet" href="{{ '/assets/css/monokai.css' | relative_url }}">
 <div class="container mx-auto">
   <div id="page" class="prose dark:prose-invert md:prose-lg max-w-[75ch] prose-neutral mx-auto pb-10 pt-20 lg:pt-[90px] lg:pb-20">
-    <h1 class="text-left text-2xl font-bold md:text-5xl text-black">{{page.title}}</h1>
+    <h1 class="text-left text-2xl font-bold md:text-5xl">{{page.title}}</h1>
     <div class="my-6">
       {{content}}
     </div>


### PR DESCRIPTION
Thank you for this jekyll theme, I am working on a community site and this theme is making it look very nice! :)

Three changes in this PR:
1. page.title in _layouts/page.html had `text-black` causing it to remain black in dark mode

Light Mode:
<img width="2960" height="264" alt="image" src="https://github.com/user-attachments/assets/baadded7-6311-4094-96f6-88cd601ef461" />

Dark Mode:
<img width="2948" height="296" alt="image" src="https://github.com/user-attachments/assets/69dab08b-9c68-44c0-a98c-5dfeff5dd72d" />

2. footer.html had a link to a different website.  (perhaps change this to a configurable URL?)

3. typo in README.  ScreenShots -> Screenshots